### PR TITLE
Feature/fengsha moisture

### DIFF
--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run FV3 ccpp_prebuild step
 
-on: [push, pull_request]
+off: [push, pull_request]
 
 jobs:
   ccpp-prebuild-FV3:

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run FV3 ccpp_prebuild step
 
-off: [push, pull_request]
+on: [push, pull_request]
 
 jobs:
   ccpp-prebuild-FV3:

--- a/physics/smoke_dust/dust_data_mod.F90
+++ b/physics/smoke_dust/dust_data_mod.F90
@@ -44,24 +44,10 @@ module dust_data_mod
   ! Never used:
   ! real(kind_phys), parameter :: fengsha_alpha = 0.3
   ! real(kind_phys), parameter :: fengsha_gamma = 1.3
+
   ! -- FENGSHA threshold velocities based on Dale A. Gillette's data
   integer, parameter :: fengsha_maxstypes = 13
-!  real(kind_phys), dimension(fengsha_maxstypes) :: dust_uthres = &
-!    (/ 0.065,   & ! Sand            - 1
-!       0.20,    & ! Loamy Sand      - 2
-!       0.52,    & ! Sandy Loam      - 3
-!       0.50,    & ! Silt Loam       - 4
-!       0.50,    & ! Silt            - 5
-!       0.60,    & ! Loam            - 6
-!       0.73,    & ! Sandy Clay Loam - 7
-!       0.73,    & ! Silty Clay Loam - 8
-!       0.80,    & ! Clay Loam       - 9
-!       0.95,    & ! Sandy Clay      - 10
-!       0.95,    & ! Silty Clay      - 11
-!       1.00,    & ! Clay            - 12
-!       9.999 /)   ! Other           - 13
-!  dust_uthres = 0.065, 0.18, 0.27, 0.30, 0.35, 0.38, 0.35, 0.41, 0.41,
-!                0.45,0.50,0.45,9999.0
+
   real(kind_phys), dimension(fengsha_maxstypes), parameter :: dust_uthres = &
     (/ 0.065,   & ! Sand            - 1
        0.18,    & ! Loamy Sand      - 2
@@ -76,12 +62,16 @@ module dust_data_mod
        0.50,    & ! Silty Clay      - 11
        0.45,    & ! Clay            - 12
        9999.0 /)   ! Other           - 13
-  ! -- FENGSHA uses precalculated drag partition from ASCAT. See: Prigent et al. (2012,2015)
+
+  ! -- FENGSHA uses precalculated drag partition
   integer, parameter :: dust_calcdrag = 1
-
-  real(kind_phys) :: dust_alpha = 2.2
+  ! -- FENGSHA dust moisture parameterization 1:fecan  -  2:shao 
+  integer :: dust_moist_opt = 1
+  
+  real(kind_phys) :: dust_alpha = 1.0
   real(kind_phys) :: dust_gamma = 1.0
-
+  real(kind_phys) :: dust_moist_correction = 1.0
+  real(kind_phys) :: dust_drylimit_factor = 1.0
 
   ! -- sea salt parameters
   integer,            dimension(nsalt), parameter :: spoint    = (/ 1, 2, 2, 2, 2, 2, 3, 3, 3 /)  ! 1 Clay, 2 Silt, 3 Sand
@@ -93,7 +83,7 @@ module dust_data_mod
     (/      1.,     0.2,     0.2,     0.2,     0.2,     0.2,   0.333,   0.333,   0.333 /)
 
 
-  ! -- soil vagatation parameters
+  ! -- soil vegatation parameters
   integer, parameter :: max_soiltyp = 30
   real(kind_phys), dimension(max_soiltyp), parameter :: &
     maxsmc = (/ 0.421, 0.464, 0.468, 0.434, 0.406, 0.465, &

--- a/physics/smoke_dust/rrfs_smoke_wrapper.F90
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.F90
@@ -12,7 +12,8 @@
                                      num_moist, num_chem, num_emis_seas, num_emis_dust, &
                                      DUST_OPT_FENGSHA, p_qv, p_atm_shum, p_atm_cldq,    &
                                      p_smoke, p_dust_1, p_coarse_pm, epsilc
-   use dust_data_mod,         only : dust_alpha, dust_gamma
+   use dust_data_mod,         only : dust_alpha, dust_gamma, dust_moist_opt, &
+                                     dust_moist_correction, dust_drylimit_factor
    use plume_data_mod,        only : p_frp_std, p_frp_hr, num_frp_plume
    use seas_mod,              only : gocart_seasalt_driver
    use dust_fengsha_mod,      only : gocart_dust_fengsha_driver
@@ -49,6 +50,7 @@ contains
                    ebb_smoke_hr, frp_hr, frp_std_hr,                                       &
                    coef_bb, ebu_smoke,fhist, min_fplume, max_fplume, hwp, wetness,         &
                    smoke_ext, dust_ext, ndvel, ddvel_inout,rrfs_sd,                        &
+                   dust_moist_opt_in, dust_moist_correction_in, dust_drylimit_factor_in,   & 
                    dust_alpha_in, dust_gamma_in, fire_in,                                  &
                    seas_opt_in, dust_opt_in, drydep_opt_in, coarsepm_settling_in,          &
                    do_plumerise_in, plumerisefire_frq_in, addsmoke_flag_in,                &
@@ -91,12 +93,15 @@ contains
     real(kind_phys), dimension(:,:), intent(out) :: smoke_ext, dust_ext
     real(kind_phys), dimension(:,:), intent(inout) :: nwfa, nifa
     real(kind_phys), dimension(:,:), intent(inout) :: ddvel_inout
-    real (kind=kind_phys), dimension(:), intent(in) :: wetness
-    integer, intent(in   ) :: imp_physics, imp_physics_thompson
-    real (kind=kind_phys), intent(in) :: dust_alpha_in, dust_gamma_in, wetdep_ls_alpha_in
-    integer,        intent(in) :: seas_opt_in, dust_opt_in, drydep_opt_in,        &
-                                  coarsepm_settling_in, plumerisefire_frq_in,     &
-                                  addsmoke_flag_in, wetdep_ls_opt_in
+    real(kind_phys), dimension(:), intent(in) :: wetness
+    real(kind_phys), intent(in) :: dust_alpha_in, dust_gamma_in, wetdep_ls_alpha_in
+    real(kind_phys), intent(in) :: dust_moist_correction_in
+    real(kind_phys), intent(in) :: dust_drylimit_factor_in
+    integer, intent(in) :: dust_moist_opt_in
+    integer, intent(in) :: imp_physics, imp_physics_thompson
+    integer, intent(in) :: seas_opt_in, dust_opt_in, drydep_opt_in,        &
+                           coarsepm_settling_in, plumerisefire_frq_in,     &
+                           addsmoke_flag_in, wetdep_ls_opt_in
     logical, intent(in   ) :: do_plumerise_in, rrfs_sd
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -314,6 +319,9 @@ contains
        ! Set at compile time in dust_data_mod:
        dust_alpha = dust_alpha_in
        dust_gamma = dust_gamma_in
+       dust_moist_opt = dust_moist_opt_in
+       dust_moist_correction = dust_moist_correction_in
+       dust_drylimit_factor = dust_drylimit_factor_in
        call gocart_dust_fengsha_driver(dt,chem,rho_phy,smois,p8w,ssm,   &
             isltyp,vegfrac,snowh,xland,dxy,g,emis_dust,ust,znt,         &
             clayf,sandf,rdrag,uthr,                                     &

--- a/physics/smoke_dust/rrfs_smoke_wrapper.meta
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.meta
@@ -612,6 +612,32 @@
   dimensions = ()
   type = logical
   intent = in
+[dust_moist_opt_in]
+  standard_name = control_for_dust_soil_moisture_option
+  long_name = smoke dust moisture parameterization 1 - fecan 2 - shao
+  units = index
+  dimensions = ()
+  type = integer
+  active = (do_smoke_coupling)
+  intent = in
+[dust_moist_correction_in]
+  standard_name = dust_moist_correction_fengsha_dust_scheme
+  long_name = moisture correction term for fengsha dust emission
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+  intent = in
+[dust_drylimit_factor_in]
+  standard_name = dust_drylimit_factor_fengsha_dust_scheme
+  long_name = moisture correction term for drylimit in fengsha dust emission
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+  intent = in 
 [dust_alpha_in]
   standard_name = alpha_fengsha_dust_scheme
   long_name = alpha paramter for fengsha dust scheme


### PR DESCRIPTION
This PR does several things 

- Cleans up dust_data_mod a little 
- adds new default options for fengsha
- adds an option for the moisture correction 1) use current FECAN 1999  2) Shao parameterization based on volumetric soil moisture 
- adds a tuning knob to the volumetric soil moisture within fengsha 
- adds a tuning knob to the drylimit used in the FECAN soil moisture parameterization 
- Corrects the conversion from volumetric to gravimetric soil moisture (from fractional to percentage) to be inline with the FECAN parameterization 
- moves the soil moisture to the second level (2cm) in RUC from the first (0 cm) 