### PR TITLE
Add wet/dry dep, hourly average HWP, wind gust, heat flux hooks

### DIFF
--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -151,6 +151,13 @@
   dimensions = ()
   type = logical
   intent = in
+[do_wetrm_thmp]
+  standard_name = do_aerosol_wet_removal_thompson
+  long_name = flag for wet removal of aerosols in Thompson MP
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [nc]
   standard_name = mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = cloud droplet number concentration
@@ -400,6 +407,21 @@
   long_name = rain number concentration
   units = kg-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ndvel]
+  standard_name = number_of_chemical_species_deposited
+  long_name = number of chemical pbl deposited
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[chem3d]
+  standard_name = chem3d_mynn_pbl_transport
+  long_name = mynn pbl transport of smoke and dust
+  units = various
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_chemical_species_vertically_mixed)
   type = real
   kind = kind_phys
   intent = inout
@@ -749,6 +771,34 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
+  intent = inout
+[do_wetrm_thmp]
+  standard_name = do_aerosol_wet_removal_thompson
+  long_name = flag for wet removal of aerosols in Thompson MP
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[wetdpr_smoke]
+  standard_name = wet_deposition_flux_thompson_mp_smoke
+  long_name = wet deposition flux of smoke in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  intent = inout
+[wetdpr_dust]
+  standard_name = wet_deposition_flux_thompson_mp_dust_1
+  long_name = wet deposition flux of fine dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  intent = inout
+[wetdpr_coarsepm]
+  standard_name = wet_deposition_flux_thompson_mp_coarse_pm
+  long_name = wet deposition flux of coarse dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
   intent = inout
 [errmsg]
   standard_name = ccpp_error_message

--- a/physics/smoke_dust/dep_data_mod.F90
+++ b/physics/smoke_dust/dep_data_mod.F90
@@ -1,0 +1,193 @@
+!>\file  dep_data_mod.F90
+!! This file contains data for the dry deposition modules.
+module dep_data_mod
+
+  use machine , only : kind_phys
+
+  integer, parameter :: nvegtype = 25
+  real(kind_phys), dimension(nvegtype), parameter :: &
+        kpart = (/500., 500., 500., 500., 500., &
+                  500., 500., 500., 500., 500., &
+                  500., 500., 500., 500., 500., &
+                  500., 500., 500., 500., 500., &
+                  500., 500., 500., 500., 500.    /)
+  real(kind_phys), parameter :: max_dep_vel = 0.5
+  real(kind_phys), parameter :: dep_ref_hgt = 2.0                     ! Meters 
+  real(kind_phys), parameter :: pi = 3.1415926536
+!  3*PI
+  REAL(kind_phys), PARAMETER :: threepi=3.0*pi
+  real(kind_phys), parameter :: gravity =  9.81
+! mean gravitational acceleration [ m/sec**2 ]
+  REAL(kind_phys), PARAMETER :: grav=9.80622
+  real(kind_phys), parameter :: boltzmann = 1.3807e-16
+! universal gas constant [ J/mol-K ]
+  REAL(kind_phys), PARAMETER :: rgasuniv=8.314510
+! Avogadro's Constant [ 1/mol ]
+  REAL, PARAMETER :: avo=6.0221367E23
+  ! Boltzmann's Constant [ J / K ]i\
+  REAL(kind_phys), PARAMETER :: boltz=rgasuniv/avo
+  real(kind_phys), parameter :: Cb = 2., Cim = 0.4, alpha = 0.8, Cin = 2.5, vv = 0.8
+  real(kind_phys), parameter :: A_for = 0.1 ! forest
+  real(kind_phys), parameter :: A_grs = 0.2 ! grass
+  real(kind_phys), parameter :: A_wat = 100. ! water
+  real(kind_phys), parameter :: eps0_for = 0.8*0.01 ! forest
+  real(kind_phys), parameter :: eps0_grs = 0.4*0.01 ! grass
+  real(kind_phys), parameter :: eps0_wat = 0.6*0.01 ! water
+
+  REAL(kind_phys), PARAMETER :: one3=1.0/3.0
+  REAL(kind_phys), PARAMETER :: two3=2.0/3.0
+!  SQRT( 2 )
+  REAL(kind_phys), PARAMETER :: sqrt2=1.4142135623731
+!  SQRT( PI )
+  REAL(kind_phys), PARAMETER :: sqrtpi=1.7724539
+  REAL(kind_phys) :: karman = 0.4                             ! von Karman constant
+  REAL(kind_phys), PARAMETER :: conmin= 1.E-16
+  REAL(kind_phys), PARAMETER :: pirs=3.14159265358979324
+  REAL(kind_phys), PARAMETER :: f6dpi=6.0/pirs
+  REAL(kind_phys), PARAMETER :: f6dpim9=1.0E-9*f6dpi
+  REAL(kind_phys), PARAMETER :: rhosmoke = 1.4E3
+  REAL(kind_phys), PARAMETER :: rhodust  = 2.6E3
+  REAL(kind_phys), PARAMETER :: smokefac=f6dpim9/rhosmoke
+  REAL(kind_phys), PARAMETER :: dustfac=f6dpim9/rhodust
+!  starting standard surface temperature [ K ]
+  REAL(kind_phys), PARAMETER :: tss0=288.15
+  REAL(kind_phys), PARAMETER :: sigma1 = 1.8
+  REAL(kind_phys), PARAMETER :: mean_diameter1 = 4.e-8
+  REAL(kind_phys), PARAMETER :: fact_wfa = 1.e-9*6.0/pirs*exp(4.5*log(sigma1)**2)/mean_diameter1**3
+  REAL(kind_phys), PARAMETER :: sginia=2.00
+!  initial sigma-G for nucleimode                 
+  REAL(kind_phys), PARAMETER :: sginin=1.70
+! initial sigma-G for coarse mode               
+  REAL(kind_phys), PARAMETER :: sginic=2.5
+!  starting standard surface pressure [ Pa ]  
+  REAL(kind_phys), PARAMETER :: pss0=101325.0
+! lowest particle diameter ( m )   
+  REAL(kind_phys), PARAMETER :: dgmin=1.0E-09
+! lowest particle density ( Kg/m**3 )
+  REAL(kind_phys), PARAMETER :: densmin=1.0E03
+! index for Aitken mode number                  
+  INTEGER, PARAMETER :: vdnnuc=1
+! index for accumulation mode number            
+  INTEGER, PARAMETER :: vdnacc=2
+! index for coarse mode number                  
+  INTEGER, PARAMETER :: vdncor=3
+! index for Aitken mode mass                    
+  INTEGER, PARAMETER :: vdmnuc=4
+! index for accumulation mode                   
+  INTEGER, PARAMETER :: vdmacc=5
+! index for fine mode mass (Aitken + accumulation)
+  INTEGER, PARAMETER :: vdmfine=6
+! index for coarse mode mass                    
+  INTEGER, PARAMETER :: vdmcor=7
+! index for Aitken mode number                  
+  INTEGER, PARAMETER :: vsnnuc=1
+! index for Accumulation mode number            
+  INTEGER, PARAMETER :: vsnacc=2
+! index for coarse mode number                  
+  INTEGER, PARAMETER :: vsncor=3
+! index for Aitken mode mass                     
+  INTEGER, PARAMETER :: vsmnuc=4
+! index for accumulation mode mass              
+  INTEGER, PARAMETER :: vsmacc=5
+! index for coarse mass                         
+  INTEGER, PARAMETER :: vsmcor=6
+! coarse mode exp( log^2( sigmag )/8 )  
+! nuclei        **4                    
+      REAL(kind_phys) :: esn04
+! accumulation                         
+      REAL(kind_phys) :: esa04
+      REAL(kind_phys) :: esc04
+! coarse                               
+! nuclei        **5                    
+      REAL(kind_phys) :: esn05
+      REAL(kind_phys) :: esa05
+! accumulation                         
+! nuclei        **8                    
+      REAL(kind_phys) :: esn08
+! accumulation                         
+      REAL(kind_phys) :: esa08
+      REAL(kind_phys) :: esc08
+! coarse                               
+! nuclei        **9                    
+      REAL(kind_phys) :: esn09
+      REAL(kind_phys) :: esa09
+! accumulation                         
+! nuclei        **12                   
+      REAL(kind_phys) :: esn12
+! accumulation                         
+      REAL(kind_phys) :: esa12
+      REAL(kind_phys) :: esc12
+! coarse mode                          
+! nuclei        **16                   
+      REAL(kind_phys) :: esn16
+! accumulation                         
+      REAL(kind_phys) :: esa16
+      REAL(kind_phys) :: esc16
+! coarse                               
+! nuclei        **20                   
+      REAL(kind_phys) :: esn20
+! accumulation                         
+      REAL(kind_phys) :: esa20
+      REAL(kind_phys) :: esc20
+! coarse                               
+! nuclei        **25                   
+      REAL(kind_phys) :: esn25
+      REAL(kind_phys) :: esa25
+! accumulation                         
+! nuclei        **24                   
+      REAL(kind_phys) :: esn24
+! accumulation                         
+      REAL(kind_phys) :: esa24
+      REAL(kind_phys) :: esc24
+! coarse                               
+! nuclei        **28                   
+      REAL(kind_phys) :: esn28
+! accumulation                         
+      REAL(kind_phys) :: esa28
+      REAL(kind_phys) :: esc28
+! coarse                               
+! nuclei        **32                   
+      REAL(kind_phys) :: esn32
+! accumulation                         
+      REAL(kind_phys) :: esa32
+      REAL(kind_phys) :: esc32
+! coarese                              
+! nuclei        **36                   
+      REAL(kind_phys) :: esn36
+! accumulation                         
+      REAL(kind_phys) :: esa36
+      REAL(kind_phys) :: esc36
+! coarse                               
+! nuclei        **49                   
+      REAL(kind_phys) :: esn49
+      REAL(kind_phys) :: esa49
+! accumulation                         
+! nuclei        **52                   
+      REAL(kind_phys) :: esn52
+      REAL(kind_phys) :: esa52
+! accumulation                         
+! nuclei        **64                   
+      REAL(kind_phys) :: esn64
+! accumulation                         
+      REAL(kind_phys) :: esa64
+      REAL(kind_phys) :: esc64
+! coarse                               
+      REAL(kind_phys) :: esn100
+! nuclei        **100                  
+! nuclei        **(-20)                
+      REAL(kind_phys) :: esnm20
+! accumulation                         
+      REAL(kind_phys) :: esam20
+      REAL(kind_phys) :: escm20
+! coarse                               
+! nuclei        **(-32)                
+      REAL(kind_phys) :: esnm32
+! accumulation                         
+      REAL(kind_phys) :: esam32
+      REAL(kind_phys) :: escm32
+!SAM 10/08 Gaussian quadrature constants for SOA_VBS deposition numerical
+!integration
+  INTEGER, PARAMETER ::  NGAUSdv= 7   ! Number of Gaussian Quadrature Points
+  REAL(kind_phys) :: xxlsgn, xxlsga, xxlsgc
+  REAL(kind_phys) :: Y_GQ(NGAUSdv), WGAUS(NGAUSdv)
+end module dep_data_mod

--- a/physics/smoke_dust/dep_dry_mod_emerson.F90
+++ b/physics/smoke_dust/dep_dry_mod_emerson.F90
@@ -1,0 +1,418 @@
+!>\file dep_dry_mod.F90
+!! This file is for the dry depostion driver.
+!-------------REVISION HISTORY---------------!
+! XX/XX/XXXX : original implementation (Ravan Ahmadov)
+! 08/17/2023 : modified to follow Emerson et al., (2020) (Jordan Schnell)
+! 08/17/2023 : gravitational settling folowing the coarse pm settling driver (Jordan Schnell)
+
+module dep_dry_emerson_mod
+
+  use machine ,        only : kind_phys
+  use dep_data_mod     ! JLS
+  use rrfs_smoke_config
+
+  implicit none
+
+  private
+
+  public :: dry_dep_driver_emerson
+
+contains
+    subroutine dry_dep_driver_emerson(rmol,ustar,znt,ndvel,ddvel,vgrav,   &
+               chem,delz,snowh,t_phy,p_phy,rho_phy,ivgtyp,g0,dt,          &
+               settling_flag,                                             &
+               ids,ide, jds,jde, kds,kde,                                 &
+               ims,ime, jms,jme, kms,kme,                                 &
+               its,ite, jts,jte, kts,kte                                  )
+!
+! compute dry deposition velocity for aerosol particles
+! Based on Emerson et al. (2020), PNAS,
+! www.pnas.org/cgi/doi/10.1073/pnas.2014761117
+! Code adapted from Hee-Ryu and Min, (2022):
+! https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2021MS002792
+!----------------------------------------------------------------------
+  IMPLICIT NONE
+ 
+       INTEGER,  INTENT(IN   ) ::  settling_flag,ndvel,                    &
+                                   ids,ide, jds,jde, kds,kde,              &
+                                   ims,ime, jms,jme, kms,kme,              &
+                                   its,ite, jts,jte, kts,kte
+       REAL(kind_phys), DIMENSION( ims:ime , jms:jme )        ,            &
+           INTENT(INOUT) :: ustar, rmol, znt, snowh
+       REAL(kind_phys), DIMENSION( ims:ime , kms:kme , jms:jme ),          &
+           INTENT(IN   ) :: t_phy, rho_phy, p_phy, delz                    
+       INTEGER, DIMENSION(ims:ime,jms:jme), INTENT(IN) ::  ivgtyp          
+       REAL(kind_phys), DIMENSION( ims:ime, kms:kme, jms:jme, num_chem ),  &
+                                             INTENT(INOUT ) :: chem
+       REAL(kind_phys), INTENT(IN) :: g0,dt
+ !
+ ! Output arrays
+       REAL(kind_phys), DIMENSION( ims:ime, jms:jme, ndvel ), INTENT(INOUT) :: ddvel
+       REAL(kind_phys), DIMENSION( ims:ime, kms:kme, jms:jme, ndvel), &
+                                                              INTENT(OUT)   :: vgrav
+ ! Local
+       REAL(kind_phys), DIMENSION( ims:ime , jms:jme )  :: aer_res
+       REAL(kind_phys), DIMENSION( ndvel ) :: cblk
+ ! Modpar variables, mass, density, diameter, knudsen number, mean free path
+       REAL(kind_phys) :: pmasssn,pmassa,pmassc,pdensn,pdensa,pdensc,      &
+                          dgnuc,dgacc,dgcor,knnuc,knacc,kncor,xlm
+       real(kind_phys) :: Cc                      ! Cunningham/slip correction factor [-]
+       real(kind_phys) :: DDp, Eb                 ! Brownian diffusion []
+       real(kind_phys) :: Eim                     ! Impaction []
+       real(kind_phys) :: Ein                     ! Interception []
+       real(kind_phys) :: Sc                      ! Schmit number []
+       real(kind_phys) :: St                      ! Stokes number []
+       real(kind_phys) :: vg                      ! gravitational settling [cm/s]
+       real(kind_phys) :: A, eps0, dumalnsg       ! land surface params [-]
+       real(kind_phys) :: amu, amu_corrected      ! dynamic viscosity [g/s]
+       real(kind_phys) :: airkinvisc              ! Air kinetic viscosity [cm2/s]
+       real(kind_phys) :: freepath                ! Air molecular freepath [cm]
+       real(kind_phys) :: dp                      ! aerosol diameter [cm]
+       real(kind_phys) :: aerodens                ! aerosol density [g/cm3] 
+       real(kind_phys) :: Rs                      ! Surface resistance
+       real(kind_phys) :: vgpart
+       real(kind_phys) :: growth_fac,vsettl,dtmax,conver,converi,dzmin
+       real(kind_phys), dimension( kts:kte) :: rho_col, delz_col
+       real(kind_phys), dimension(ndvel)    :: dt_settl
+       real(kind_phys), dimension( kts:kte, ndvel ) :: cblk_col, vg_col
+       integer, dimension(ndvel) :: ndt_settl
+       integer :: i, j, k, ntdt, nv
+       real(kind_phys) :: chem_before
+ ! chem pointers (p_*) are not sequentially numbered, need to define so nv loops work
+       integer, dimension(ndvel) :: chem_pointers
+       chem_pointers(1) = p_smoke
+       chem_pointers(2) = p_dust_1
+       chem_pointers(3) = p_coarse_pm
+  
+       growth_fac = 1.0
+       conver=1.e-9
+       converi=1.e9
+ 
+       do j = jts, jte
+          do i = its, ite
+             aer_res(i,j) = 0.0
+             do k = kts, kte
+                delz_col(k) = delz(i,k,j)
+                rho_col(k)  = rho_phy(i,k,j)
+                do nv = 1, ndvel
+                   cblk(nv) = chem(i,k,j,chem_pointers(nv))
+                   if ( k == kts ) then
+                      ddvel(i,j,nv) = 0.0
+                      dt_settl(nv)  = 0.0
+                   endif ! k==kts
+                end do ! nv
+                ! *** U.S. Standard Atmosphere 1962 page 14 expression
+                !     for dynamic viscosity = beta * T * sqrt(T) / ( T + S)
+                !     where beta = 1.458e-6 [ kg sec^-1 K**-0.5 ], s = 110.4 [ K ].
+                amu = 1.458E-6 * t_phy(i,k,j) * sqrt(t_phy(i,k,j)) / ( t_phy(i,k,j) + 110.4 )
+                ! Aerodynamic resistance
+                call depvel( rmol(i,j), dep_ref_hgt, znt(i,j), ustar(i,j), vgpart, aer_res(i,j) ) 
+                ! Get the aerosol properties dp and aerodens and mean free path (xlm)
+                ! FOR RRFS-SD, diameters and densities are explicityly defined
+                !call modpar( cblk,t_phy(i,k,j),p_phy(i,k,j), amu,               &
+                !             pmasssn,pmassa,pmassc,pdensn,pdensa,pdensc,        &
+                !             dgnuc,dgacc,dgcor,knnuc,knacc,kncor,xlm, ndvel     )
+                ! Air kinematic viscosity (cm^2/s)
+                airkinvisc = ( 1.8325e-4 * ( 416.16 / ( t_phy(i,k,j) + 120.0 ) ) *   &
+                             ( ( t_phy(i,k,j) / 296.16 )**1.5 ) ) / ( rho_phy(i,k,j) * 1.e3 ) ! Convert density to g/cm^3
+                ! Air molecular freepath (cm)  ! Check against XLM from above
+                freepath = 7.39758e-4 * airkinvisc / sqrt( t_phy(i,k,j) )
+                do nv = 1, ndvel
+                   if ( chem_pointers(nv) == p_smoke ) then
+                      dp = 4.E-8 !dgacc
+                      aerodens = 1.4e+3 !pdensa
+                   elseif ( chem_pointers(nv) == p_dust_1) then
+                      dp = 1.E-6 !dgacc 
+                      aerodens = 2.6e+3 !pdensa
+                   elseif ( chem_pointers(nv) == p_coarse_pm ) then
+                      dp = 4.5E-6 !dgcor
+                      aerodens = 2.6e+3 !pdensc
+                   else
+                      continue
+                   endif
+                   ! Convert diameter to cm and aerodens to g/cm3
+                   aerodens = aerodens / 1000.
+                   dp = dp * 1e+2
+                   ! Cunningham correction factor
+                   Cc = 1. + 2. * freepath / dp * ( 1.257 + 0.4*exp( -0.55 * dp / freepath ) )
+                   ! Corrected dynamic viscosity (used for settling)
+                   amu_corrected = amu / Cc
+                   ! Gravitational Settling
+                   vg = aerodens * dp * dp * gravity * 100. * Cc / &       ! Convert gravity to cm/s^2
+                          ( 18. * airkinvisc * ( rho_phy(i,k,j) * 1.e3 ) ) ! Convert density to g/cm^3
+                   ! -- Rest of loop for the surface when deposition velocity needs to be cacluated
+                   if ( k == kts ) then
+                      ! Brownian Diffusion
+                      DDp = ( boltzmann * t_phy(i,k,j) ) * Cc / (3. * pi * airkinvisc * ( rho_phy(i,k,j) * 1.e3 )  * dp) ! Convert density to g/cm^3
+                      ! Schmit number
+                      Sc = airkinvisc / DDp
+                      ! Brownian Diffusion
+                      Eb = Cb * Sc**(-0.666666667)
+                      ! Stokes number
+                      St = ( 100. * ustar(i,j) ) * ( 100.* ustar(i,j) ) * vg / airkinvisc / ( gravity * 100.) ! Convert ustar to cm/s, gravity to cm/s^2
+                      ! Impaction 
+                      Eim = Cim * ( St / ( alpha + St ) )**1.7
+                      ! MODIS type lu, large roughness lengths (e.g., urban or forest)
+                      ! -----------------------------------------------------------------------
+                      ! *** TO DO -- set A and eps0 for all land surface types *** !!!
+                      ! -----------------------------------------------------------------------
+                      if ( ivgtyp(i,j) .eq. 13 .or. ivgtyp(i,j) .le. 5 ) then ! Forest
+                         A = A_for
+                         eps0 = eps0_for
+                      else if ( ivgtyp(i,j) .eq. 17 ) then ! water
+                         A = A_wat
+                         eps0 = eps0_wat
+                      else ! otherwise
+                         A = A_grs
+                         eps0 = eps0_grs
+                      end if
+                      ! Set if snow greater than 1 cm
+!                      if ( snowh(i,j) .gt. 0.01 ) then ! snow
+!                         A = A_wat
+!                         eps0 = eps0_wat
+!                      endif
+                      ! Interception
+                      Ein = Cin * ( dp / A )**vv
+                      ! Surface resistance
+                      Rs = 1. / ( ( ustar(i,j) * 100.) * ( Eb + Eim + Ein) * eps0 ) ! Convert ustar to cm/s
+                      ! Compute final ddvel = settling + aer_res + RS, set max at 0.5  [ cm/s]
+                      ddvel(i,j,nv) = min( vg + 1. / (aer_res(i,j) + Rs ), max_dep_vel)
+                   endif ! k == kts
+                   vgrav(i,k,j,nv) = vg
+                   ! Fill column variables
+                   cblk_col(k,nv) = cblk(nv)
+                   vg_col(k,nv)   = vg
+                enddo ! nv
+             enddo ! k
+             ! -- Get necessary info for settling
+             ! -- Determine the maximum time-step satisying the CFL condition:
+             dzmin = minval(delz_col)
+             ntdt=INT(dt)
+             do nv = 1, ndvel
+               ! -- NOTE, diameters and densities are NOT converted to cm and g/cm3 like above
+               ! -- dt_settl calculations (from original coarsepm_settling)
+               if ( chem_pointers(nv) == p_smoke ) then
+                 dp = 4.E-8 !dgacc
+                 aerodens = 1.4e+3 !pdensa
+               elseif ( chem_pointers(nv) == p_dust_1) then
+                 dp = 1.E-6 !dgacc 
+                 aerodens = 2.6e+3 !pdensa
+               elseif ( chem_pointers(nv) == p_coarse_pm ) then
+                 dp = 4.5E-6 !dgcor
+                 aerodens = 2.6e+3 !pdensc
+               else
+                 continue
+               endif
+               ! 1.5E-5 = dyn_visc --> dust_data_mod.F90
+               vsettl = 2.0 / 9.0 * g0 * aerodens * ( growth_fac * ( 0.5 * dp ))**2.0 / ( 0.5 * 1.5E-5 )
+               dtmax = dzmin / vsettl
+               ndt_settl(nv) = MAX( 1, INT( ntdt /dtmax) )
+               ! Limit maximum number of iterations
+               IF (ndt_settl(nv) > 12) ndt_settl(nv) = 12 
+               dt_settl(nv) = REAL(ntdt) / REAL(ndt_settl(nv))
+             enddo
+             chem_before = sum(cblk_col(kts:kte,3))
+             ! Perform gravitational settling if desired
+             if ( settling_flag == 1 ) then
+                call particle_settling(cblk_col,rho_col,delz_col,vg_col,dt_settl,ndt_settl,ndvel,kts,kte)
+             endif
+             ! Put cblk back into chem array
+             do k = kts, kte
+                do nv= 1, ndvel
+                   chem(i,k,j,chem_pointers(nv)) = cblk_col(k,nv)
+                enddo ! nv
+             enddo ! k                      
+        end do ! j
+        end do ! i
+end subroutine dry_dep_driver_emerson
+!
+!--------------------------------------------------------------------------------
+!
+subroutine depvel( rmol, zr, z0, ustar, vgpart, aer_res )
+!--------------------------------------------------
+!     THIS FUNCTION HAS BEEN DESIGNED TO EVALUATE AN UPPER LIMIT
+!     FOR THE POLLUTANT DEPOSITION VELOCITY AS A FUNCTION OF THE
+!     SURFACE ROUGHNESS AND METEOROLOGICAL CONDITIONS.
+!     PROGRAM WRITTEN BY GREGORY J.MCRAE (NOVEMBER 1977)
+!         Modified by Darrell A. Winner  (Feb. 1991)
+!                  by Winfried Seidl     (Aug. 1997)
+!.....PROGRAM VARIABLES...
+!     RMOL     - RECIPROCAL OF THE MONIN-OBUKHOV LENGTH
+!     ZR       - REFERENCE HEIGHT
+!     Z0       - SURFACE ROUGHNESS HEIGHT
+!     USTAR    - FRICTION VELOCITY U*
+!     AER_RES  - AERODYNAMIC RESISTANCE
+!.....REFERENCES...
+!     MCRAE, G.J. ET AL. (1983) MATHEMATICAL MODELING OF PHOTOCHEMICAL
+!       AIR POLLUTION, ENVIRONMENTAL QUALITY LABORATORY REPORT 18,
+!       CALIFORNIA INSTITUTE OF TECHNOLOGY, PASADENA, CALIFORNIA.
+!.....RESTRICTIONS...
+!     1. THE MODEL EDDY DIFFUSIVITIES ARE BASED ON MONIN-OBUKHOV
+!        SIMILARITY THEORY AND SO ARE ONLY APPLICABLE IN THE
+!        SURFACE LAYER, A HEIGHT OF O(30M).
+!     2. ALL INPUT UNITS MUST BE CONSISTENT
+!     3. THE PHI FUNCTIONS USED TO CALCULATE THE FRICTION
+!        VELOCITY U* AND THE POLLUTANT INTEGRALS ARE BASED
+!        ON THE WORK OF BUSINGER ET AL.(1971).
+!     4. THE MOMENTUM AND POLLUTANT DIFFUSIVITIES ARE NOT
+!        THE SAME FOR THE CASES L<0 AND L>0.
+!--------------------------------------------------
+! .. Scalar Arguments ..
+!--------------------------------------------------
+        REAL(kind_phys), intent(in)    :: ustar, z0, zr
+        REAL(kind_phys), intent(out)   :: vgpart, aer_res
+        REAL(kind_phys), intent(inout) :: rmol
+!--------------------------------------------------
+! .. Local Scalars ..
+!--------------------------------------------------
+        INTEGER :: l
+        REAL(kind_phys)    :: ao, ar, polint, vk
+!--------------------------------------------------
+! .. Intrinsic Functions ..
+!--------------------------------------------------
+        INTRINSIC alog
+!--------------------------------------------------
+!     Set the von Karman constant
+!--------------------------------------------------
+        vk = karman
+!--------------------------------------------------
+!     DETERMINE THE STABILITY BASED ON THE CONDITIONS
+!             1/L < 0 UNSTABLE
+!             1/L = 0 NEUTRAL
+!             1/L > 0 STABLE
+!--------------------------------------------------
+        if(abs(rmol) < 1.E-6 ) rmol = 0.
+        IF (rmol<0) THEN
+          ar = ((1.0-9.0*zr*rmol)**(0.25)+0.001)**2
+          ao = ((1.0-9.0*z0*rmol)**(0.25)+0.001)**2
+          polint = 0.74*(alog((ar-1.0)/(ar+1.0))-alog((ao-1.0)/(ao+1.0)))
+        ELSE IF (rmol==0.) THEN
+          polint = 0.74*alog(zr/z0)
+        ELSE
+          polint = 0.74*alog(zr/z0) + 4.7*rmol*(zr-z0)
+        END IF
+        vgpart = ustar*vk/polint
+        aer_res = polint/(karman*max(ustar,1.0e-4))
+end subroutine depvel
+!
+!--------------------------------------------------------------------------------
+!
+subroutine modpar(  cblk, blkta, blkprs, amu,                   &
+                    pmassn,pmassa,pmassc, pdensn,pdensa,pdensc, &
+                    dgnuc,dgacc,dgcor,knnuc,knacc,kncor, xlm,ndvel   )
+        IMPLICIT NONE
+
+        INTEGER, INTENT(IN) :: ndvel
+        REAL(kind_phys), DIMENSION(ndvel), INTENT( IN) :: cblk
+        REAL(kind_phys), INTENT(IN ) :: blkta, blkprs, amu
+        REAL(kind_phys), INTENT(OUT) :: pmassn,pmassa,pmassc,pdensn,pdensa,pdensc, &
+                                        dgnuc,dgacc,dgcor,knnuc,knacc,kncor,xlm
+!
+! Local
+        REAL(kind_phys) :: xxlsgn,xxlsga,xxlsgc,l2sginin,l2sginia,l2sginic, &
+                           en1,ea1,ec1,esn04,esa04,esc04, &
+                           esn08,esa08,esc08,esn16,esa16,esc16, &
+                           esn20,esa20,esc20,esn36,esa36,esc36
+        REAL(kind_phys), DIMENSION( 6 )     :: nblk ! number densities
+! Pointers
+        INTEGER, PARAMETER :: vnu0  = 1
+        INTEGER, PARAMETER :: vac0  = 2
+        INTEGER, PARAMETER :: vcorn = 3
+        INTEGER, PARAMETER :: vnu3  = 4
+        INTEGER, PARAMETER :: vac3  = 5
+        INTEGER, PARAMETER :: vcor3 = 6
+!
+        xxlsgn = log(sginin)
+        xxlsga = log(sginia)
+        xxlsgc = log(sginic)
+        l2sginin = xxlsgn**2
+        l2sginia = xxlsga**2
+        l2sginic = xxlsgc**2
+        en1 = exp(0.125*l2sginin)
+        ea1 = exp(0.125*l2sginia)
+        ec1 = exp(0.125*l2sginic)
+        esn04 = en1**4
+        esa04 = ea1**4
+        esc04 = ec1**4
+        esn08 = esn04*esn04
+        esa08 = esa04*esa04
+        esc08 = esc04*esc04
+        esn16 = esn08*esn08
+        esa16 = esa08*esa08
+        esc16 = esc08*esc08
+        esn20 = esn16*esn04
+        esa20 = esa16*esa04
+        esc20 = esc16*esc04
+        esn36 = esn16*esn20
+        esa36 = esa16*esa20
+        esc36 = esc16*esc20
+! First step in WRF-Chem is to add together the aitken, accumulation, and coarse modes
+! Calculate number densities
+        nblk(vnu0)  = max(conmin,0.0)
+        nblk(vnu3)  = max(conmin,0.0)
+        nblk(vac0)  = max(conmin, (cblk(1)/rhosmoke + cblk(2)/rhodust)*fact_wfa)
+        nblk(vcorn) = max(conmin, cblk(3)/rhodust*fact_wfa)
+        nblk(vac3)  = max(conmin,smokefac*cblk(2) + dustfac*cblk(1)) ! Accumulation is smoke + fine dust
+        nblk(vcor3) = max(conmin,dustfac*cblk(3))
+! Dust in coarse
+        pmassn = max(conmin,0.0)
+        pmassa = max(conmin,cblk(1) + cblk(2))
+        pmassc = max(conmin,cblk(3))
+        pdensn = max(conmin,0.0)
+        pdensa = max(densmin,(f6dpim9*pmassa/nblk(vac3)))
+        pdensc = max(densmin,(f6dpim9*pmassc/nblk(vcor3)))
+! Calculate mean free path
+        xlm    = 6.6328E-8*pss0*blkta/(tss0*blkprs*1.e3)
+! Calculate diameters
+        dgnuc  = max(dgmin,0.0)
+        dgacc  = max(dgmin,(nblk(vac3)/(nblk(vac0)*esa36))**one3)
+        dgcor  = max(dgmin,(nblk(vcor3)/(nblk(vcorn)*esc36))**one3)
+! Calculate Knudsen numbers
+        knnuc  = 2.0*xlm/dgnuc
+        knacc  = 2.0*xlm/dgacc
+        kncor  = 2.0*xlm/dgcor
+end subroutine modpar
+!
+!--------------------------------------------------------------------------------
+!
+subroutine particle_settling(cblk,rho_phy,delz,vg,dt_settl,ndt_settl,ndvel,kts,kte)
+     IMPLICIT NONE
+     
+     INTEGER, INTENT(IN ) :: kts, kte, ndvel
+     REAL(kind_phys), DIMENSION(kts:kte), INTENT (IN)  :: rho_phy, delz
+     REAL(kind_phys), DIMENSION(kts:kte,ndvel), INTENT(IN) :: vg
+     REAL(kind_phys), DIMENSION(kts:kte,ndvel), INTENT(INOUT) :: cblk
+     REAL(kind_phys), DIMENSION(ndvel), INTENT(IN) :: dt_settl
+     INTEGER, DIMENSION(ndvel), INTENT(IN) :: ndt_settl
+!
+!--- Local------
+     INTEGER :: k,nv,n,l2
+     REAL(kind_phys) :: temp_tc, transfer_to_below_level, vd_wrk1
+     REAL(kind_phys), DIMENSION(kts:kte) :: delz_flip 
+     
+     do k = kts,kte
+        delz_flip(k) = delz(kte-k+kts)
+     enddo
+
+     do nv = 1, ndvel
+     do n = 1,ndt_settl(nv)
+     transfer_to_below_level = 0.0
+     do k = kte,kts,-1
+        l2 = kte - k + 1
+     
+        temp_tc = cblk(k,nv)
+     
+        vd_wrk1 = dt_settl(nv) * vg(k,nv)/100. / delz_flip(l2)               ! convert vg to m/s
+     
+        cblk(k,nv)= cblk(k,nv) * (1. - vd_wrk1) + transfer_to_below_level
+        if (k.gt.kts) then
+            transfer_to_below_level =(temp_tc*vd_wrk1)*((delz_flip(l2) &
+                        *rho_phy(k))/(delz_flip(l2+1)*rho_phy(k-1)))          ! [ug/kg]
+        endif
+     enddo ! k
+     enddo ! n
+     enddo ! nv
+end subroutine particle_settling
+
+!
+end module dep_dry_emerson_mod

--- a/physics/smoke_dust/dep_dry_simple_mod.F90
+++ b/physics/smoke_dust/dep_dry_simple_mod.F90
@@ -1,7 +1,7 @@
-!>\file dep_dry_mod.F90
+!>\file dep_dry_simple_mod.F90
 !! This file is for the dry depostion driver.
 
-module dep_dry_mod
+module dep_dry_simple_mod
 
   use machine ,        only : kind_phys
 
@@ -9,11 +9,11 @@ module dep_dry_mod
 
   private
 
-  public :: dry_dep_driver
+  public :: dry_dep_driver_simple
 
 contains
 
-    subroutine dry_dep_driver(rmol,ust,ndvel,ddvel,rel_hum,               &
+    subroutine dry_dep_driver_simple(rmol,ust,ndvel,ddvel,rel_hum,               &
                ids,ide, jds,jde, kds,kde,                                 &
                ims,ime, jms,jme, kms,kme,                                 &
                its,ite, jts,jte, kts,kte                                  )
@@ -64,6 +64,6 @@ contains
          enddo
         enddo
 
-end subroutine dry_dep_driver
+end subroutine dry_dep_driver_simple
 
-end module dep_dry_mod
+end module dep_dry_simple_mod

--- a/physics/smoke_dust/module_plumerise1.F90
+++ b/physics/smoke_dust/module_plumerise1.F90
@@ -38,6 +38,7 @@ subroutine ebu_driver (      flam_frac,ebb_smoke,ebu,           &
                              t_phy,q_vap,                            &   ! RAR: moist is replaced with q_vap
                              rho_phy,vvel,u_phy,v_phy,p_phy,         &
                              z_at_w,z,g,con_cp,con_rd,               &   ! scale_fire_emiss is part of config_flags
+                             fire_heat_flux,dxy,                     &
                              plume_frp, k_min, k_max,                &   ! RAR:
                              ids,ide, jds,jde, kds,kde,              &
                              ims,ime, jms,jme, kms,kme,              &
@@ -66,6 +67,8 @@ subroutine ebu_driver (      flam_frac,ebb_smoke,ebu,           &
    real(kind=kind_phys), INTENT(IN )  :: g, con_cp, con_rd
    real(kind=kind_phys), DIMENSION( ims:ime, jms:jme ), INTENT(IN )  :: ebb_smoke
    real(kind=kind_phys), DIMENSION( ims:ime, jms:jme ), INTENT(OUT ) :: flam_frac
+   real(kind=kind_phys), DIMENSION( ims:ime, jms:jme ), INTENT(OUT ) :: fire_heat_flux
+   real(kind=kind_phys), DIMENSION( ims:ime, jms:jme ), INTENT(IN )  :: dxy
 
 !   real(kind=kind_phys), DIMENSION( ims:ime, 1, jms:jme ),                 &
 !         INTENT(IN ) ::                                   ebu_in
@@ -184,6 +187,7 @@ check_pl:  IF (do_plumerise) THEN    ! if the namelist option is set for plumeri
                               !num_ebu, eburn_in, eburn_out,         &
                               u_in, v_in, w_in, theta_in ,pi_in,    &
                               rho_phyin, qv_in, zmid, z_lev,        &
+                              fire_heat_flux(i,j),dxy(i,j),         &
                               plume_frp(i,j,1), k_min(i,j),         & 
                               k_max(i,j), dbg_opt, g, con_cp,       &
                               con_rd, cpor, errmsg, errflg )

--- a/physics/smoke_dust/module_smoke_plumerise.F90
+++ b/physics/smoke_dust/module_smoke_plumerise.F90
@@ -28,6 +28,7 @@ CONTAINS
 !                         firesize,mean_fct,                         &
                         ! nspecies,eburn_in,eburn_out,               &
                          up,vp,wp,theta,pp,dn0,rv,zt_rams,zm_rams,  &
+                         fire_heat_flux, dxy,                       &
                          frp_inst,k1,k2, dbg_opt, g, cp, rgas,      &
                          cpor,  errmsg, errflg   )
 
@@ -42,6 +43,9 @@ CONTAINS
   real(kind=kind_phys) :: g, cp, rgas, cpor
 
   integer :: ng,m1,m2,m3,ia,iz,ja,jz,ibcon,mynum,i,j,k,imm,ixx,ispc !,nspecies
+
+  real(kind=kind_phys), intent(in)  :: dxy
+  real(kind=kind_phys), intent(out) :: fire_heat_flux 
 
   INTEGER, INTENT (OUT) :: k1,k2
   character(*), intent(inout) :: errmsg
@@ -106,6 +110,7 @@ CONTAINS
 IF (frp_inst<frp_threshold) THEN
    k1=1
    k2=2
+   fire_heat_flux = 0.
    !return
 END IF
     
@@ -172,7 +177,7 @@ END IF
          END IF
     
        !- get fire properties (burned area, plume radius, heating rates ...)
-       call get_fire_properties(coms,imm,iveg_ag,burnt_area,FRP,errmsg,errflg)
+       call get_fire_properties(coms,imm,iveg_ag,burnt_area,FRP,dxy,fire_heat_flux,errmsg,errflg)
        if(errflg/=0) return
 
        !------  generates the plume rise    ------
@@ -434,12 +439,14 @@ end subroutine set_grid
   END SUBROUTINE set_flam_vert
 !-------------------------------------------------------------------------
 
-subroutine get_fire_properties(coms,imm,iveg_ag,burnt_area,FRP,errmsg,errflg)
+subroutine get_fire_properties(coms,imm,iveg_ag,burnt_area,FRP,dxy,heat_flux_out,errmsg,errflg)
 !use module_zero_plumegen_coms
 implicit none
 type(plumegen_coms), pointer :: coms
 integer ::  moist,  i,  icount,imm,iveg_ag  !,plumerise_flag
 real(kind=kind_phys)::   bfract,  effload,  heat,  hinc ,burnt_area,heat_fluxW,FRP
+real(kind=kind_phys), intent(in) :: dxy
+real(kind=kind_phys), intent(out) :: heat_flux_out
 !real(kind=kind_phys),    dimension(2,4) :: heat_flux
 integer, intent(inout) :: errflg
 character(*), intent(inout) :: errmsg
@@ -458,6 +465,7 @@ coms%area = burnt_area! area of burn, m^2
 !ELSEIF ( PLUMERISE_flag == 2) THEN
     ! "beta" factor converts FRP to convective energy
     heat_fluxW = beta*(FRP/coms%area)/0.55 ! in W/m^2
+    heat_flux_out = heat_fluxW * coms%area / dxy
 ! FIXME: These five lines were not in the known-working version. Delete them?
 !    if(coms%area<1e-6) then
 !      heat_fluxW = 0

--- a/physics/smoke_dust/module_wetdep_ls.F90
+++ b/physics/smoke_dust/module_wetdep_ls.F90
@@ -3,11 +3,12 @@
 
 module module_wetdep_ls
   use machine ,          only : kind_phys
-  use rrfs_smoke_config, only : p_qc, alpha => wetdep_ls_alpha
+  use rrfs_smoke_config, only : p_smoke, p_dust_1, p_coarse_pm, p_qc, alpha => wetdep_ls_alpha
 
 contains
 subroutine wetdep_ls(dt,var,rain,moist,                                         &
                      rho,nchem,num_moist,dz8w,vvel,                             &
+                     wetdpr_smoke, wetdpr_dust, wetdpr_coarsepm,                &
                      ids,ide, jds,jde, kds,kde,                                 &
                      ims,ime, jms,jme, kms,kme,                                 &
                      its,ite, jts,jte, kts,kte )
@@ -21,6 +22,8 @@ subroutine wetdep_ls(dt,var,rain,moist,                                         
    real(kind_phys), dimension( ims:ime, kms:kme, jms:jme, num_moist),intent(in) :: moist
    real(kind_phys), dimension( ims:ime, kms:kme, jms:jme),intent(in) :: rho,dz8w,vvel        
    real(kind_phys), dimension( ims:ime, kms:kme, jms:jme,1:nchem),intent(inout) :: var        
+   real(kind_phys), dimension( ims:ime, jms:jme ), intent(out) :: &
+                                              wetdpr_smoke, wetdpr_dust, wetdpr_coarsepm
    real(kind_phys), dimension( ims:ime, jms:jme),intent(in) :: rain
    real(kind_phys), dimension( its:ite, jts:jte) :: var_sum,var_rmv
    real(kind_phys), dimension( its:ite, kts:kte, jts:jte) :: var_rmvl
@@ -68,6 +71,14 @@ subroutine wetdep_ls(dt,var,rain,moist,                                         
           if(var(i,k,j,nv).gt.1.e-16 .and. moist(i,k,j,p_qc).gt.0.)then
             factor = max(0.,frc(i,j)*rho(i,k,j)*dz8w(i,k,j)*vvel(i,k,j))
             dvar=alpha*factor/(1+factor)*var(i,k,j,nv)
+! Accumulate diags
+            if (nv .eq. p_smoke ) then
+               wetdpr_smoke(i,j) = wetdpr_smoke(i,j) + dvar * rho(i,k,j) * dt * 1.E-6 
+            elseif (nv .eq. p_dust_1 ) then
+               wetdpr_dust(i,j) = wetdpr_dust(i,j) + dvar * rho(i,k,j) * dt * 1.E-6
+            elseif (nv .eq. p_coarse_pm ) then
+               wetdpr_coarsepm(i,j) = wetdpr_coarsepm(i,j) + dvar * rho(i,k,j) * dt * 1.E-6
+            endif
             var(i,k,j,nv)=max(1.e-16,var(i,k,j,nv)-dvar)
           endif
          enddo

--- a/physics/smoke_dust/rrfs_smoke_config.F90
+++ b/physics/smoke_dust/rrfs_smoke_config.F90
@@ -26,7 +26,7 @@ module rrfs_smoke_config
   integer :: plumerisefire_frq=60
   integer :: wetdep_ls_opt = 1
   integer :: drydep_opt  = 1
-  integer :: coarsepm_settling = 1
+  integer :: pm_settling = 1
   logical :: bb_dcycle   = .false.
   logical :: aero_ind_fdb = .false.
   logical :: dbg_opt     = .true.

--- a/physics/smoke_dust/rrfs_smoke_postpbl.meta
+++ b/physics/smoke_dust/rrfs_smoke_postpbl.meta
@@ -1,8 +1,7 @@
 [ccpp-table-properties]
   name = rrfs_smoke_postpbl
   type = scheme
-  dependencies = dep_dry_mod.F90,module_wetdep_ls.F90,dust_data_mod.F90,dust_fengsha_mod.F90,module_add_emiss_burn.F90,module_plumerise1.F90,module_smoke_plumerise.F90,module_zero_plumegen_coms.F90,plume_data_mod.F90,rrfs_smoke_config.F90,seas_data_mod.F90,seas_mod.F90,seas_ngac_mod.F90
-
+  dependencies = dep_dry_simple_mod.F90,module_wetdep_ls.F90,dust_data_mod.F90,dust_fengsha_mod.F90,module_add_emiss_burn.F90,module_plumerise1.F90,module_smoke_plumerise.F90,module_zero_plumegen_coms.F90,plume_data_mod.F90,rrfs_smoke_config.F90,seas_data_mod.F90,seas_mod.F90,seas_ngac_mod.F90,dep_dry_mod_emerson.F90,dep_data_mod.F90
 ########################################################################
 [ccpp-arg-table]
   name = rrfs_smoke_postpbl_run

--- a/physics/smoke_dust/rrfs_smoke_wrapper.meta
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = rrfs_smoke_wrapper
   type = scheme
-  dependencies = dep_dry_mod.F90,module_wetdep_ls.F90,dust_data_mod.F90,dust_fengsha_mod.F90,module_add_emiss_burn.F90,module_plumerise1.F90,module_smoke_plumerise.F90,module_zero_plumegen_coms.F90,plume_data_mod.F90,rrfs_smoke_config.F90,seas_data_mod.F90,seas_mod.F90,seas_ngac_mod.F90,coarsepm_settling_mod.F90
+  dependencies = dep_dry_simple_mod.F90,module_wetdep_ls.F90,dust_data_mod.F90,dust_fengsha_mod.F90,module_add_emiss_burn.F90,module_plumerise1.F90,module_smoke_plumerise.F90,module_zero_plumegen_coms.F90,plume_data_mod.F90,rrfs_smoke_config.F90,seas_data_mod.F90,seas_mod.F90,seas_ngac_mod.F90,coarsepm_settling_mod.F90, dep_dry_mod_emerson.F90,dep_data_mod.F90
 
 ########################################################################
 [ccpp-arg-table]
@@ -558,6 +558,51 @@
   type = real
   kind = kind_phys
   intent = inout
+[wetdpr_smoke]
+  standard_name = wet_deposition_flux_thompson_mp_smoke
+  long_name = wet deposition flux of smoke in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  intent = inout
+[wetdpr_dust]
+  standard_name = wet_deposition_flux_thompson_mp_dust_1
+  long_name = wet deposition flux of fine dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  intent = inout
+[wetdpr_coarsepm]
+  standard_name = wet_deposition_flux_thompson_mp_coarse_pm
+  long_name = wet deposition flux of coarse dust in thomposon microphysics
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  intent = inout
+[drydep_flux_smoke]
+  standard_name = dry_deposition_flux_smoke
+  long_name = rrfs dry deposition flux of smoke
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[drydep_flux_dust_1]
+  standard_name = dry_deposition_flux_dust_1
+  long_name = rrfs dry deposition flux of fine dust
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[drydep_flux_coarse_pm]
+  standard_name = dry_deposition_flux_coarse_pm
+  long_name = rrfs dry deposition flux of coarse dust
+  units = ug m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [hwp]
   standard_name = hourly_wildfire_potential
   long_name = rrfs hourly fire weather potential
@@ -566,6 +611,14 @@
   type = real
   kind = kind_phys
   intent = out
+[hwp_ave]
+  standard_name = hourly_wildfire_potential_average
+  long_name = rrfs hourly fire weather potential average
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [wetness]
   standard_name = normalized_soil_wetness_for_land_surface_model
   long_name = normalized soil wetness
@@ -683,9 +736,9 @@
   dimensions = ()
   type = integer
   intent = in
-[coarsepm_settling_in]
-  standard_name = control_for_smoke_coarsepm_settling
-  long_name = rrfs smoke coarsepm settling option
+[pm_settling_in]
+  standard_name = control_for_smoke_pm_settling
+  long_name = rrfs smoke pm settling option
   units = index
   dimensions = ()
   type = integer
@@ -739,6 +792,29 @@
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+[fire_heat_flux_out]
+  standard_name = surface_fire_heat_flux
+  long_name = heat flux of fire at the surface
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[kpbl]
+  standard_name = vertical_index_at_top_of_atmosphere_boundary_layer
+  long_name = PBL top model level index
+  units = index
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = in
+[oro]
+  standard_name = height_above_mean_sea_level
+  long_name = height_above_mean_sea_level
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
   intent = in
 [dbg_opt_in]
   standard_name = do_smoke_debug


### PR DESCRIPTION
1. New dry deposition option following Emerson et al. (2020) with gravitational settling
2. Gravitational settling now controlled by namelist pm_settling (was coarsepm_settling)
3. Calculation of HOURLY-AVERAGE HWP
4. Pass out fire_heat_flux to be used by Tanya's updates
5. Calculation of wind gust potential using PBLH from MYNN (following UPP)
6. Wet deposition from resolved precipitation in Thompson MP controlled by logical namelist: wraerosol
7. Resolved wet deposition diagnostics